### PR TITLE
ci: fix by installing latest obsidian dep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Node install latest tree
         if: matrix.install-exact == 0
         run: |
+          npm update
           npm install
 
       - run: npm run build --if-present

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      # obsidian package often fails integrity checks since its a tarball, hence will get the 
+      # obsidian package often fails integrity checks since its a tarball, hence will get the get the tarball -> npm will cache it -> npm ci will test integrity of that cache vs package-lock.json 
+      # https://github.com/ShootingKing-AM/Obsidian_to_Anki/pull/122
       - run: |
           npm install obsidian 
           npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
+        install-exact: [1, 0] 
 
     steps:
       - uses: actions/checkout@v3
@@ -26,9 +27,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # obsidian package often fails integrity checks since its a tarball, hence will get the get the tarball -> npm will cache it -> npm ci will test integrity of that cache vs package-lock.json 
       # https://github.com/ShootingKing-AM/Obsidian_to_Anki/pull/122
-      - run: |
+      # Installing exact tree would be used in CI/CD to exactly reproduce tests
+      - name: Node install exact tree
+        if: matrix.install-exact == 1
+        run: |
           npm install obsidian 
           npm ci
+        
+      # Install latest tree would be usually done by devs/who locally build the plugin
+      - name: Node install latest tree
+        if: matrix.install-exact == 0
+        run: |
+          npm install
+
       - run: npm run build --if-present
       # - run: npm test
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      # obsidian package often fails integrity checks since its a tarball, hence will get the 
+      - run: |
+          npm install obsidian 
+          npm ci
       - run: npm run build --if-present
       # - run: npm test
       

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -27,7 +27,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_V }}
-      - run: npm ci
+      - run: |
+          npm install obsidian 
+          npm ci
       - run: npm run build --if-present
       
       - name: Run Tests

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "chromedriver": "^100.0.0",
         "devtools": "^8.12.1",
         "glob": "^9.3.0",
-        "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+        "obsidian": "latest",
         "rollup": "^2.32.1",
         "rollup-plugin-node-polyfills": "^0.2.1",
         "showdown-highlight": "^3.1.0",


### PR DESCRIPTION
- this should have been fixed by https://github.com/npm/cli/issues/2971 but still its present in npm 9
- obsidian package often fails integrity checks since its a tarball (tarball will not have the same integrity, different download versions of tar will have diff), hence will get the get the tarball -> npm will cache it -> npm ci will test integrity of that cache vs package-lock.json 

- specific to CI, to replicate, do npm ci locally then, npm cache clear -force (this will delete the npm downloaded tarball), the do npm ci (which will again download the git tarball, now the integrity will mismatch)

- Seems related: https://github.com/npm/cli/issues/4460