### PR TITLE
Fix the Obsidian Tag RegExp

### DIFF
--- a/src/note.ts
+++ b/src/note.ts
@@ -12,7 +12,7 @@ const TAG_PREFIX:string = "Tags: "
 export const TAG_SEP:string = " "
 export const ID_REGEXP_STR: string = String.raw`\n?(?:<!--)?(?:ID: (\d+).*)`
 export const TAG_REGEXP_STR: string = String.raw`(Tags: .*)`
-const OBS_TAG_REGEXP: RegExp = /#(\w+)/g
+const OBS_TAG_REGEXP: RegExp = /(?:^|[\t ])(#[a-zA-Z0-9\/_-]*[a-zA-Z\/_-][a-zA-Z0-9\/_-]*)+/g
 
 const ANKI_CLOZE_REGEXP: RegExp = /{{c\d+::[\s\S]+?}}/
 export const CLOZE_ERROR: number = 42


### PR DESCRIPTION
In reference to issue 536 on the old repo, since that doesn't seem to be maintained anymore

The new RegExp matches tags exactly like Obsidian ([documentation on the topic](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format)). It's adapted slightly from [here](https://forum.obsidian.md/t/what-is-the-formal-syntax-surrounding-tags/12949/2).